### PR TITLE
fix an oozie ssh action bug:

### DIFF
--- a/core/src/main/java/org/apache/oozie/WorkflowJobBean.java
+++ b/core/src/main/java/org/apache/oozie/WorkflowJobBean.java
@@ -207,7 +207,7 @@ public class WorkflowJobBean implements Writable, WorkflowJob, JsonBean {
 
     @Basic
     @Column(name = "run")
-    private int run = 1;
+    private int run;
 
     @Basic
     @Index


### PR DESCRIPTION
executing a not exists command in ssh action would be success rather than fail.
it's caused by:
1. WorkflowJobBean.run is set to 0 while start action.
2. WorkflowJobBean.run is init to 1 while check action status. (this patch change the 1 to 0.)
3. WorkflowJobBean.run is part of ActionExecutorContext.recoveryId.
4. SshActionExecutor check command result status by the file existence of ${ActionExecutorContext.recoveryId}.error.
